### PR TITLE
Feature/accesslog/customize parser

### DIFF
--- a/mackerel-plugin-accesslog/lib/accesslog.go
+++ b/mackerel-plugin-accesslog/lib/accesslog.go
@@ -200,7 +200,7 @@ func Do() {
 	var parser axslogparser.Parser
 	switch *optFormat {
 	case "":
-		parser = nil // guess format by log
+		parser = nil // guess format by log (default)
 	case "ltsv":
 		parser = &axslogparser.LTSV{}
 	case "apache":

--- a/mackerel-plugin-accesslog/lib/accesslog_test.go
+++ b/mackerel-plugin-accesslog/lib/accesslog_test.go
@@ -3,6 +3,8 @@ package mpaccesslog
 import (
 	"reflect"
 	"testing"
+
+	"github.com/Songmu/axslogparser"
 )
 
 var fetchMetricsTests = []struct {
@@ -80,5 +82,61 @@ func TestFetchMetrics(t *testing.T) {
 		if !reflect.DeepEqual(out, tt.Output) {
 			t.Errorf("%s: \n out:  %#v\n want: %#v", tt.Name, out, tt.Output)
 		}
+	}
+}
+
+func TestFetchMetricsWithCustomParser(t *testing.T) {
+	// OK case
+	p := &AccesslogPlugin{
+		file:      "testdata/sample-ltsv.tsv",
+		noPosFile: true,
+		parser:    &axslogparser.LTSV{},
+	}
+	out, err := p.FetchMetrics()
+	if err != nil {
+		t.Errorf("error should be nil but: %+v", err)
+		return
+	}
+
+	expected := map[string]float64{
+		"2xx_count":      7,
+		"3xx_count":      1,
+		"4xx_count":      1,
+		"5xx_count":      1,
+		"total_count":    10,
+		"2xx_percentage": 70,
+		"3xx_percentage": 10,
+		"4xx_percentage": 10,
+		"5xx_percentage": 10,
+		"average":        0.7603999999999999,
+		"90_percentile":  2.018,
+		"95_percentile":  3.018,
+		"99_percentile":  3.018,
+	}
+	if !reflect.DeepEqual(out, expected) {
+		t.Errorf("out:  %#v\n want: %#v", out, expected)
+	}
+
+	// NG case (should not detect log format by log line)
+	p = &AccesslogPlugin{
+		file:      "testdata/sample-apache.log",
+		noPosFile: true,
+		parser:    &axslogparser.LTSV{},
+	}
+	out, err = p.FetchMetrics()
+	if err != nil {
+		t.Errorf("error should be nil but: %+v", err)
+		return
+	}
+
+	expected = map[string]float64{
+		"2xx_count":   0,
+		"3xx_count":   0,
+		"4xx_count":   0,
+		"5xx_count":   0,
+		"total_count": 0,
+	}
+	if !reflect.DeepEqual(out, expected) {
+		t.Errorf("out:  %#v\n want: %#v", out, expected)
 	}
 }


### PR DESCRIPTION
This patch makes be able to specify access log format by plugin option.
It's good when axslogparser cannot detect to correct log format.